### PR TITLE
Add shared high-level pipeline-test harness (Phase 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,199 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A CUDA C++ pipeline for real-time radio-astronomy signal processing: it ingests UDP/PCAP packet
+streams from FPGA-based receivers (the "LAMBDA" instrument), correlates and beamforms the data on
+the GPU (via the Tensor Core Correlator and ccglib matrix-multiply libraries), applies adaptive
+spatial filtering / RFI mitigation via eigendecomposition, and writes results out as
+HDF5/PSRDADA/FITS/Redis streams. There's also a Python/marimo toolkit in `scripts/` for offline
+analysis of captured PCAP and HDF5 data, and a Textual TUI in `ui/` for configuring/running CMake
+builds.
+
+## Build & test
+
+Requires CUDA, cuTENSOR, HDF5, CFITSIO, CasaCore, and PSRDADA (`$PSRHOME` env var must point at a
+PSRDADA install). Dependencies in `extern/` are git submodules — run
+`git submodule update --init --recursive` if they're missing.
+
+### Building/testing in this docker container (the normal way you'll be run)
+
+The container ships a conda environment at `/opt/conda` alongside system packages, and a few
+things need pointing at non-default locations for configure/build/run to all succeed. Use a fresh
+build directory (the checked-in `build/` has a stale cache pointing at a no-longer-existent path,
+`/tmp/cuda-spatial-filtering` — don't try to reconfigure it; make a new one, e.g. `build_test`):
+
+```bash
+mkdir build_test && cd build_test
+
+# CUTENSOR_ROOT: the env var defaults to /usr/lib/x86_64-linux-gnu/libcutensor, which has
+# version-numbered subdirs (11/, 11.0/, 12/) and no top-level include/ -- find_cutensor.cmake
+# (cmake/find_cutensor.cmake) needs the flat ${CUTENSOR_ROOT}/include + ${CUTENSOR_ROOT}/lib
+# layout that /opt/conda happens to have instead:
+CUTENSOR_ROOT=/opt/conda cmake -DBUILD_TESTING=ON ..
+cmake --build . -- -j$(nproc)
+
+# CUDA_HOME: needed at *runtime* (not just configure time) -- see the NVRTC note below.
+export CUDA_HOME=/opt/conda/targets/x86_64-linux
+ctest                                    # run everything
+ctest -R ProcessorStateTest              # filter by test-suite name (regex)
+./tests/CUDASpatialFilteringTests --gtest_filter='*SimpleTest*'   # run a gtest binary directly
+```
+
+Two non-obvious things that will otherwise produce confusing failures:
+
+- **Link errors like `undefined reference to 'arc4random@GLIBC_2.36'` /
+  `strlcpy@GLIBC_2.38'` / `__isoc23_strtoull@GLIBC_2.38'`** when linking any test binary (or
+  `apps/*`): the linker resolved `libc.so.6` against an *older* glibc than the system libraries it's
+  linking against (`libcurl`, `libpcap`, `gtest`, `libcasa_*`, ...) were built against. The cause:
+  `/opt/conda/bin/g++` sits earlier in `$PATH` than `/usr/bin/g++` and defaults to its own bundled
+  cross-sysroot glibc (capped at `GLIBC_2.35`, vs. the container's system glibc `2.39`). Fix by
+  forcing the link step to resolve against the system glibc — pass this when configuring (it's a
+  build-directory/cache setting; don't bake it into the repo's `CMakeLists.txt`, since it's purely
+  a function of this container's toolchain layering):
+  ```bash
+  CUTENSOR_ROOT=/opt/conda cmake -DBUILD_TESTING=ON \
+    -DCMAKE_EXE_LINKER_FLAGS="-Wl,--sysroot=/ -L/usr/lib/x86_64-linux-gnu -Wl,-rpath-link,/usr/lib/x86_64-linux-gnu" \
+    ..
+  ```
+- **`NVRTC_ERROR_COMPILATION` / "cannot open source file `cooperative_groups/memcpy_async.h`"
+  at runtime** (not a build failure — the binary links fine and fails when *run*): any test or app
+  that constructs a `tcc::Correlator` (i.e. builds a `LambdaGPUPipeline`-family pipeline)
+  JIT-compiles `TCCorrelator.cu` via NVRTC at runtime, and NVRTC needs the CUDA toolkit's
+  `include/` directory for headers like `cooperative_groups/*.h`.
+  `Correlator::findNVRTCincludePath()` (`extern/tcc/libtcc/Correlator.cc`) checks `$CUDA_HOME`,
+  then `$CUDA_PATH`, then `$CONDA_PREFIX` (looking for `<prefix>/include/cuda.h` or
+  `<prefix>/targets/x86_64-linux/include/cuda.h`) before falling back to introspecting
+  `libnvrtc.so`'s load path — so export one of those before running anything that touches the
+  correlator, e.g. `export CUDA_HOME=/opt/conda/targets/x86_64-linux`.
+
+(OzStar — not the primary environment, but documented for completeness — instead does
+`module load cuda/12.6.0 gcc/13.3.0 cmake/3.29.3`, which keeps the host compiler's glibc and the
+system's in sync and avoids both issues above.)
+
+Test binaries (see `tests/CMakeLists.txt`): `CUDASpatialFilteringTests` (test_spatial.cpp, mostly
+disabled/commented-out correlation experiments), `PipelineTests` (test_pipeline.cu, GPU pipeline
+kernels), `CUDASpatialFilteringCPUTests` (test_packet_formats.cpp, CPU-only packet parsing),
+`WriterTests` (test_writers.cpp, HDF5 writers), `ProcessorTests` (test_processor.cu, the packet
+ring-buffer/`ProcessorState` machinery), `PipelineHarnessSelfTest` (support/test_harness_selftest.cu,
+proves out the shared pipeline-test harness in `tests/support/` — see `tests/TESTING.md`), plus
+`test_beamforming.cpp` for beamforming math.
+
+Build options that shape the generated code (set with `-D...`, see top-level `CMakeLists.txt`):
+`NR_OBSERVING_BUFFERS`, `NR_OBSERVING_FPGA_SOURCES`, `NR_OBSERVING_CHANNELS`,
+`NR_OBSERVING_RECEIVERS_PER_PACKET`, `NR_OBSERVING_PADDED_RECEIVERS`,
+`NR_OBSERVING_PACKETS_FOR_CORRELATION`, `NR_OBSERVING_CORRELATION_BLOCKS_TO_INTEGRATE`,
+`NUMBER_BEAMS`. These become `add_compile_definitions` and feed directly into the `LambdaConfig`
+template instantiations in each app's `main()`. They only apply to the `apps` subdirectory build
+(skipped when `BUILD_TESTING=ON`).
+
+The Textual TUI in `ui/` (`cd ui && hatch run ui`, or `python ui.py`) is a convenience wrapper for
+setting these CMake cache variables and kicking off a build/configure.
+
+## Architecture
+
+The pipeline is a producer/consumer system glued together by **`LambdaConfig`** — a single struct
+template (in `include/spatial/packet_formats.hpp`) that's parameterized over every dimension of the
+problem (`NR_CHANNELS`, `NR_FPGA_SOURCES`, `NR_RECEIVERS`, `NR_PACKETS_FOR_CORRELATION`,
+`NR_BEAMS`, `NR_PADDED_RECEIVERS`, ...). It defines all the derived array types
+(`PacketSamplesType`, `InputPacketSamplesType`, `Visibilities`, `BeamOutput`, etc.) used throughout
+the rest of the code as compile-time-shaped multidimensional C arrays. Every app instantiates its
+own concrete `Config = LambdaConfig<...>` from the `NR_OBSERVING_*` macros and threads it through
+as a template parameter — so most of the "business logic" classes are themselves templates on `T`
+(a `LambdaConfig` instantiation), e.g. `ProcessorState<T>`, `LambdaGPUPipeline<T>`,
+`SingleHostMemoryOutput<T>`.
+
+Data flow, end to end:
+
+1. **Packet capture** (`PacketInput` hierarchy in `include/spatial/spatial.hpp`,
+   implementations in `src/spatial.cpp`): `KernelSocketPacketCapture` (live UDP socket),
+   `PCAPPacketCapture` / `PCAPMultiFPGAPacketCapture` (replay from `.pcap`/`.pcapng` files, with
+   `--loop`). `include/spatial/libibverbs.hpp` has an alternate RDMA/ibverbs-based capture path.
+   `src/ethernet.cpp` + `include/spatial/ethernet.hpp` parse raw Ethernet/IP/UDP/custom headers
+   (`packet_formats.hpp` defines the on-wire `EthernetHeader`/`IPHeader`/`UDPHeader`/`CustomHeader`
+   structs and the `LambdaPacketEntry`/`LambdaFinalPacketData` in-memory representations).
+
+2. **Buffering / reassembly** (`ProcessorStateBase` / `ProcessorState<T, NR_INPUT_BUFFERS,
+   RING_BUFFER_SIZE>` in `include/spatial/spatial.hpp`): a lock-free-ish double/triple-buffered
+   ring buffer that accumulates incoming packets per channel/FPGA, tracks missing packets, handles
+   FPGA-to-FPGA delay alignment (`fpga_delays_packet_aligned`/`fpga_delays_subpacket`), and once a
+   buffer is full, hands a `FinalPacketData*` off to a `GPUPipeline` for processing
+   (`release_buffer` is the hand-back once the GPU is done with that buffer).
+
+3. **GPU pipeline** (`GPUPipeline` abstract interface in `include/spatial/pipeline_base.hpp`;
+   concrete `Lambda*Pipeline<T>` implementations in `include/spatial/pipeline.hpp`, CUDA kernels in
+   `src/spatial.cu`/`include/spatial/spatial.cuh`, tensor permutation helpers in
+   `src/tensor.cpp`/`include/spatial/tensor.hpp`): converts/scales raw int8 samples to `__half`,
+   correlates via `libtcc::Correlator` (Tensor Core Correlator, `extern/tcc`), beamforms via
+   `ccglib` GEMM (`extern/ccglib`), computes eigendecompositions with cuSOLVER for adaptive
+   spatial filtering / RFI subtraction, and runs FFTs via cuFFT for spectra/bandpass output. Key
+   variants: `LambdaGPUPipeline` (baseline correlate+beamform), `LambdaAntennaSpectraPipeline`,
+   `LambdaBeamformedSpectraPipeline`, `LambdaAdaptiveBeamformedSpectraPipeline` (RFI mitigation via
+   eigenvector projection), `LambdaCorrBeamOnlyGPUPipeline`, `LambdaProjectionPipeline`,
+   `LambdaPulsarFoldPipeline` (folding for pulsar timing).
+
+4. **Output / writers** (`Output` interface + `SingleHostMemoryOutput<T>` /
+   `BufferedOutput<T>` in `include/spatial/output.hpp`; concrete `Writer<T>` subclasses in
+   `include/spatial/writers.hpp`): double-buffered host-memory landing zones that the GPU DMAs
+   into asynchronously (`register_*_block` / `get_*_landing_pointer` /
+   `register_*_transfer_complete`), drained by background writer threads to
+   `HDF5BeamWriter`/`HDF5VisibilitiesWriter`/`HDF5FFTWriter`/`HDF5ProjectionEigenWriter` (HighFive),
+   `PSRDADABeamWriter` (PSRDADA ring buffers), `RedisEigendataWriter`/`RedisBeamFFTWriter`
+   (redis-plus-plus, for live monitoring), and CasaCore/CFITSIO-based outputs.
+
+`include/spatial/common.hpp` is shared app glue: `parse_common_args` (the argparse setup every
+binary uses — config/gains/PCAP/interface/etc. flags → `CommonArgs`), `setup_logger` (async spdlog
+→ `app.log`), `get_gains_structure` (loads per-channel/pol/antenna calibration gains from JSON),
+and `AntennaMapRegistry` (hard-coded FPGA-stream → physical-antenna-ID maps for the LAMBDA array).
+Logging/error-check macros (`INFO_LOG`, `DEBUG_LOG`, `CUDA_CHECK`, `CUFFT_CHECK`, `CUBLAS_CHECK`,
+`CUSOLVER_CHECK`) live in `include/spatial/logging.hpp`.
+
+`src/` builds everything into a single `spatial` static library that all apps and tests link
+against (see `src/CMakeLists.txt`). Note `src/packet_formats.cpp` and `src/pipeline.cpp` are
+currently empty stubs, and `include/spatial/adaptive_pipelines.hpp` is an empty placeholder header.
+
+### Apps (`apps/`, see `apps/CMakeLists.txt`)
+
+All link `gpu_app_common` and share `parse_common_args`/`CommonArgs` from `common.hpp`. Each
+hard-codes its own `LambdaConfig` instantiation in `main()`:
+
+- `observe` — main live/PCAP-replay observing pipeline (correlate + beamform + dump visibilities).
+- `beamformed_bandpass` — beamformed spectra/bandpass output.
+- `adaptive_beamformed_bandpass` — adaptive (eigen-projection-based RFI-mitigated) beamforming.
+- `get_projection_matrix` — computes/dumps the eigenvector projection matrix used for adaptive
+  filtering (consumed later via HDF5 by `ProjectionWeightApplicator` in `beamformed-bandpass.cu`).
+- `fft_antenna_spectra` — per-antenna spectra via FFT.
+- `pulsar_fold` — folds beamformed data at a pulsar period.
+- `gpu_benchmark` — GPU kernel/pipeline benchmarking harness.
+- `udp_sender` — replays a PCAP file as a live UDP stream (for testing the live-capture path).
+
+### Domain gotchas (from prior debugging — keep these in mind when touching GPU/tensor code)
+
+- **TCC**: data points per block = `128 * COMPLEX / (N_BITS_PER_COMPONENT * COMPLEX)`, e.g. 16
+  time points/block for 8-bit components. `NR_RECEIVERS` must be a multiple of 32 (zero-pad if
+  fewer). `NR_POLARIZATIONS` must be 2 (zero-pad otherwise).
+- **ccglib**: the second GEMM operand must be column-major only in its rows/columns sections — the
+  Batch/Complex sections are *not* column-major.
+- **cuTensor**: assumes column-major modes; `tensor.cpp` does a `std::reverse` on modes/extents so
+  the rest of the code can reason in row-major terms.
+
+## Python tooling (`scripts/`, `ui/`)
+
+- `scripts/` contains marimo notebooks (`correlate-pcap.py`, `read_visibilities.py`,
+  `explore_metrics.ipynb`) for visualizing captured PCAP/HDF5 data — run with
+  `source .venv/bin/activate && marimo edit` (see `scripts/README.md` for SSH port-forwarding to
+  view the marimo UI remotely), `create_pcap.py`/`udp_sender` for synthesizing test packet
+  captures, and `mlflow_save_benchmarks*.py` for logging benchmark runs to MLflow.
+- `ui/ui.py` is a Textual TUI (`CMakeBuilder`) that exposes the `NR_OBSERVING_*`/`NUMBER_BEAMS`
+  CMake cache variables as a form and drives `cmake`/`cmake --build` for you.
+
+## Notes
+
+- Several large generated/data artifacts (`.hdf5`, `.pcap`/`.pcapng`, `.ncu-rep`, `.nsys-rep`,
+  `dump.rdb`, `*.so`, etc.) live in the repo root and `scripts/` for benchmarking/profiling and
+  analysis — they're build outputs or captured data, not source.
+- `extern/` (git submodules: tcc, ccglib, cudawrappers, libpcap, spdlog, xtensor/xtl, argparse,
+  highfive, googletest, rdma-core) is gitignored; the build `FetchContent_Declare`s each from its
+  local `SOURCE_DIR`.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,9 +42,25 @@ add_executable(
 )
 target_link_libraries(ProcessorTests PRIVATE test_app_common)
 
+# Shared high-level pipeline-test harness (tests/support/*.hpp): synthetic
+# packet builders, canonical small LambdaConfigs, a SyntheticPipelineRun driver
+# that wires a real ProcessorState to a real GPUPipeline via the synchronous
+# pipeline seam, and property-based assertion helpers. Header-only -- this
+# INTERFACE library just adds the include path so `#include "support/..."`
+# resolves, and pulls in test_app_common's dependencies.
+add_library(test_support INTERFACE)
+target_include_directories(test_support INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(test_support INTERFACE test_app_common)
+
+add_executable(
+  PipelineHarnessSelfTest support/test_harness_selftest.cu
+)
+target_link_libraries(PipelineHarnessSelfTest PRIVATE test_support)
+
 include(GoogleTest)
 gtest_discover_tests(CUDASpatialFilteringTests)
 gtest_discover_tests(CUDASpatialFilteringCPUTests)
 gtest_discover_tests(PipelineTests)
 gtest_discover_tests(WriterTests)
 gtest_discover_tests(ProcessorTests)
+gtest_discover_tests(PipelineHarnessSelfTest)

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -1,0 +1,128 @@
+# Testing strategy: the shared pipeline-test harness
+
+## The problem this solves
+
+Of the 7 `Lambda*Pipeline` GPU pipeline variants (see `include/spatial/pipeline.hpp`), only one
+(`LambdaGPUPipeline`) had any test coverage, via `test_pipeline.cu`'s ~1,300-line `Ex1` and
+friends. Most of that file is reusable setup boilerplate — building synthetic wire-format packets,
+constructing the pipeline, wiring up output buffers, driving the buffer-fill/flush sequence,
+syncing the GPU — repeated across its cases. Writing a test for any of the other 6 variants meant
+copy-pasting most of it and editing the parts that differ.
+
+`tests/support/` is the shared 80%: it turns "test pipeline variant N" into "construct it, call
+`.run(...)`, assert invariants on the `Output`."
+
+## Test at a high level, not against implementation details
+
+The guiding principle: tests should encode **physical and mathematical invariants of the data**
+(finite-ness, Hermitian symmetry where it's actually stored, eigenvalue ordering, "a known tone
+shows up at the expected FFT bin", ...) rather than asserting on specific intermediate computation
+paths or magic constants. That makes them survive refactors of the pipeline internals — including
+the LOC-reduction refactor of `pipeline.hpp` this test-coverage push exists to enable — instead of
+breaking in lockstep with them.
+
+The one deliberate exception: where the math is simple enough to hand-derive exact expected
+values (as `Ex1` does for `LambdaGPUPipeline` with unity weights and constant input), exact-value
+golden checks are kept/reused, because they're strictly stronger than invariant checks *and* cheap
+to write correctly. They are not generalized to the more complex variants (adaptive/eigen-projection
+/FFT/folding) — there, hand-deriving correct goldens is impractical and the result would be brittle;
+invariant checks are the right tool.
+
+## What drives the tests: the real production seam, end to end
+
+`tests/support/pipeline_harness.hpp`'s `SyntheticPipelineRun<Config>` wires a real
+`ProcessorState<Config>` to a real `Lambda*Pipeline<Config>` and a real `Output`, via the exact
+seam production code uses:
+
+```
+PacketInput → ProcessorState → GPUPipeline → Output
+```
+
+Concretely: it feeds synthetic on-the-wire packets through `ProcessorState`'s normal ingestion
+path (`get_current_write_pointer` / `add_received_packet_metadata` / `get_next_write_pointer`,
+the same calls `KernelSocketPacketCapture`/`PCAPPacketCapture` make), sets
+`synchronous_pipeline = true` so `ProcessorState::handle_buffer_completion()` calls
+`pipeline_->execute_pipeline(...)` directly on the calling thread (no background threads/queues —
+see `include/spatial/spatial.hpp`), and lets the result land in a real `SingleHostMemoryOutput<Config>`
+for assertions to inspect.
+
+This is intentionally *not* the same as `test_pipeline.cu`'s `DummyFinalPacketData`, which pokes
+values directly into `LambdaConfig` array layouts, bypassing `ProcessorState` ingestion entirely —
+that's a lower-level, more implementation-coupled shortcut. Driving the full real seam is what
+"test at a high level" means here: it's the same path production traffic takes, so a test failure
+means something that matters to a real run broke.
+
+## The pieces (`tests/support/`)
+
+- **`test_configs.hpp`** — canonical small `LambdaConfig` instantiations (`SmallSingleFPGAConfig`,
+  `SmallMultiFPGAConfig`) shared across tests, replacing the ad-hoc `Config`/`MultiFPGAConfig`/
+  `TestConfig`/`MockT` aliases that different test files previously each defined for themselves.
+- **`synthetic_packets.hpp`** — `build_lambda_wire_packet<Config>(...)` /
+  `feed_lambda_packet<Config>(...)`: builds a correctly-laid-out Ethernet+IP+UDP+Custom+Payload
+  wire packet (and, for the latter, pushes it through a real `ProcessorStateBase`'s write-pointer
+  protocol), parameterized by `sample_fn(time, receiver, pol)` / `scale_fn(receiver, pol)`
+  generator callbacks so callers can inject whatever data pattern they need (constant, tone, ramp,
+  ...) without duplicating wire-format byte-layout logic. Consolidates what used to be two
+  near-duplicate builders in `test_processor.cu` and `test_packet_formats.cpp`.
+- **`pipeline_harness.hpp`** — `SyntheticPipelineRun<Config>` (described above), plus
+  `make_unity_beam_weights<Config>()` / `make_unity_antenna_gains<Config>()` ("do nothing to the
+  signal" baselines), plus `pipeline_factories::make_*_pipeline<Config>(...)` — small per-variant
+  construction helpers. A single generic factory isn't realistic because the 7 pipeline classes
+  take genuinely different constructor arguments (e.g. `LambdaGPUPipeline(int, BeamWeightsT<T>*)`
+  vs `LambdaAntennaSpectraPipeline(int)` vs `LambdaProjectionPipeline<T, NR_EIG, NR_RUNS>(int)`).
+  Only `make_gpu_pipeline` exists so far; add the rest incrementally as tests for those variants
+  are written.
+- **`assertions.hpp`** — the property/invariant checks themselves:
+  `assert_all_finite` (catches NaN/Inf from uninitialized memory, bad FFT plans, eigendecomposition
+  blowups, ...), `assert_autocorrelation_invariants` (same-polarization autocorrelations are real
+  and non-negative; each receiver's polarization covariance matrix is Hermitian — see the note
+  below on why this isn't full baseline-level Hermitian symmetry), `assert_eigenvalues_ascending_nonnegative`
+  (cuSOLVER's `cusolverDnXsyevBatched` contract), `assert_tone_detected` (feed a known-frequency
+  tone, assert the FFT peak lands at the expected bin — robust to scaling/normalization changes).
+- **`test_harness_selftest.cu`** — `PipelineHarnessSelfTest`, proving the harness is wired
+  correctly by reproducing `test_pipeline.cu::Ex1`'s hand-derived exact values
+  (`beam_data == (8, -8)`, `visibilities == (64, 0)`) end to end through the harness, *and*
+  demonstrating the invariant-based style on the same run.
+
+## A gotcha this surfaced: packed triangular baseline storage
+
+The plan originally called for a generic `assert_hermitian_symmetric(visibilities)` checking
+`V[baseline(i,j)] ≈ conj(V[baseline(j,i)])`. That's not directly testable: the Tensor Core
+Correlator stores visibilities in **packed lower-triangular** form —
+`baseline_index(i, j) = j*(j+1)/2 + i`, valid only for `i <= j` (see `storeVisibility` in
+`extern/tcc/libtcc/kernel/TCCorrelator.cu`) — so there is no stored slot for the conjugate pair
+`(j, i)` when `j > i` to compare against. `assert_autocorrelation_invariants` checks the subset of
+"Hermitian visibilities" that *does* survive this storage scheme: every receiver's own
+per-polarization covariance block `V[baseline(r,r)][p][q]` is square and must still be Hermitian
+PSD, regardless of how the correlator lays out cross-baseline pairs.
+
+## A gotcha this surfaced: a likely latent race on `Output::arrivals`
+
+An earlier version of the self-test asserted that `Output::arrivals` reflected a fully-arrived
+synthetic buffer (`assert_all_packets_arrived`, since removed). It failed deterministically: the
+array came back all-`false`. Tracing it — `LambdaPipelineIngest::ingest_and_scale`
+(`include/spatial/pipeline.hpp`) queues `release_buffer_host_func` via `cudaLaunchHostFunc` on a
+per-buffer host stream *immediately* on entry; that callback calls `ProcessorState::release_buffer`,
+which `memset`s the very same buffer's `arrivals` array to zero in preparation for reuse — but the
+`std::memcpy` that copies `arrivals` out to `Output` happens ~150 lines later in the same
+`execute_pipeline`, with no synchronization between the two. With small/fast configs (i.e. exactly
+the kind tests use), the async callback reliably wins that race and zeroes the array first.
+
+This looks like a genuine pre-existing bug independent of the harness — `Output::arrivals` may be
+unreliable in production too, just masked there by larger configs giving the host thread more of a
+head start. Fixing it is real production-code work and out of scope for the test harness itself;
+it's flagged here so whoever picks it up has the trace already done. (If/when it's fixed,
+`assert_all_packets_arrived`-style precondition checks — "did the synthetic feed actually produce
+a complete buffer before asserting on pipeline output" — would be worth re-adding.)
+
+## Adding a test for a new pipeline variant
+
+1. If needed, add a `pipeline_factories::make_<variant>_pipeline<Config>(...)` to
+   `pipeline_harness.hpp` (the variant's constructor signature dictates the shape).
+2. Pick (or add) a `Config` from `test_configs.hpp` sized for the variant under test.
+3. `SyntheticPipelineRun<Config> driver(*pipeline, output, ...);` then
+   `driver.run(sample_fn, scale_fn)` (or `run_uniform` if the data pattern doesn't depend on
+   channel/FPGA/packet index).
+4. Assert on `*output-><field>` using the helpers in `assertions.hpp` — reach for invariant checks
+   first; only write exact-value goldens if the variant's math is genuinely hand-derivable (as
+   `LambdaGPUPipeline`'s is).

--- a/tests/support/assertions.hpp
+++ b/tests/support/assertions.hpp
@@ -1,0 +1,193 @@
+#pragma once
+
+#include "spatial/packet_formats.hpp"
+
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <cuda_fp16.h>
+#include <gtest/gtest.h>
+#include <limits>
+#include <string>
+#include <type_traits>
+
+// Property/invariant-based assertions for pipeline output buffers.
+//
+// These check physical and mathematical truths that must hold regardless of
+// *how* the GPU computes them (correlator internals, normalization constants,
+// kernel launch shapes, ...) -- the goal is for these checks to keep passing
+// across the planned pipeline.hpp refactor, rather than being tied to today's
+// exact intermediate values.
+//
+// Exact-value golden checks (e.g. test_pipeline.cu::Ex1's expected 8.0f/64.0f
+// results) are intentionally NOT generalized here: they only make sense for
+// LambdaGPUPipeline, the one variant simple enough to hand-derive expected
+// numbers for. For the rest (adaptive/eigen-projection/FFT/folding), invariant
+// checks like the ones below are the right tool.
+namespace test_support {
+
+// The Tensor Core Correlator stores visibilities in packed lower-triangular
+// form: baseline_index(i, j) = j*(j+1)/2 + i, valid only for i <= j (see
+// storeVisibility in extern/tcc/libtcc/kernel/TCCorrelator.cu). Only that
+// triangle (including the diagonal, i.e. autocorrelations) is physically
+// present -- there is no separate stored slot for the conjugate pair (j, i)
+// when j > i.
+inline constexpr size_t baseline_index(size_t i, size_t j) {
+  return (j * (j + 1)) / 2 + i;
+}
+
+namespace detail {
+
+inline bool is_finite_scalar(float value) { return std::isfinite(value); }
+inline bool is_finite_scalar(double value) { return std::isfinite(value); }
+inline bool is_finite_scalar(__half value) {
+  return std::isfinite(__half2float(value));
+}
+inline bool is_finite_scalar(const std::complex<float> &value) {
+  return std::isfinite(value.real()) && std::isfinite(value.imag());
+}
+
+template <typename Element>
+::testing::AssertionResult all_finite(const Element *data, size_t n,
+                                      const std::string &name) {
+  for (size_t i = 0; i < n; ++i) {
+    if (!is_finite_scalar(data[i])) {
+      return ::testing::AssertionFailure()
+             << name << "[" << i << "] is not finite";
+    }
+  }
+  return ::testing::AssertionSuccess();
+}
+
+} // namespace detail
+
+// Checks that every element of a (possibly multi-dimensional) C-array output
+// buffer is finite -- catches uninitialized memory, bad FFT plans,
+// divide-by-zero in normalization, NaNs leaking out of eigendecomposition, etc.
+template <typename Array>
+void assert_all_finite(const Array &array, const std::string &name) {
+  using Element = std::remove_all_extents_t<Array>;
+  constexpr size_t n = sizeof(Array) / sizeof(Element);
+  const Element *flat = reinterpret_cast<const Element *>(&array);
+  ASSERT_TRUE(detail::all_finite(flat, n, name));
+}
+
+// Checks the physical invariants of a per-receiver autocorrelation that hold
+// for *any* correlator: same-polarization autocorrelations are total-power
+// measurements (real, non-negative), and the per-receiver polarization
+// covariance matrix V[r][r][p][q] is Hermitian (V[p][q] == conj(V[q][p])).
+//
+// This is the part of "Hermitian visibilities" that survives the correlator's
+// packed lower-triangular baseline storage: cross-baseline conjugate pairs
+// V[baseline(j, i)] for j > i simply aren't stored, so they can't be compared
+// against V[baseline(i, j)] -- but every receiver's own polarization matrix is
+// square and must still be Hermitian PSD.
+template <typename Config>
+void assert_autocorrelation_invariants(
+    const typename Config::VisibilitiesOutputType &visibilities,
+    float tolerance = 1e-3f) {
+  for (size_t c = 0; c < Config::NR_CHANNELS; ++c) {
+    for (size_t r = 0; r < Config::NR_RECEIVERS; ++r) {
+      const size_t b = baseline_index(r, r);
+      ASSERT_LT(b, Config::NR_BASELINES_UNPADDED);
+
+      for (size_t p = 0; p < Config::NR_POLARIZATIONS; ++p) {
+        const float real = visibilities[c][b][p][p][0];
+        const float imag = visibilities[c][b][p][p][1];
+        ASSERT_NEAR(imag, 0.0f, tolerance)
+            << "channel " << c << " receiver " << r << " pol " << p
+            << ": same-polarization autocorrelation must be real (got imag="
+            << imag << ")";
+        ASSERT_GE(real, -tolerance)
+            << "channel " << c << " receiver " << r << " pol " << p
+            << ": same-polarization autocorrelation power must be "
+               "non-negative (got "
+            << real << ")";
+      }
+
+      for (size_t p = 0; p < Config::NR_POLARIZATIONS; ++p) {
+        for (size_t q = p + 1; q < Config::NR_POLARIZATIONS; ++q) {
+          const std::complex<float> v_pq(visibilities[c][b][p][q][0],
+                                         visibilities[c][b][p][q][1]);
+          const std::complex<float> v_qp(visibilities[c][b][q][p][0],
+                                         visibilities[c][b][q][p][1]);
+          ASSERT_NEAR(v_pq.real(), v_qp.real(), tolerance)
+              << "channel " << c << " receiver " << r << ": V[" << p << "][" << q
+              << "] and conj(V[" << q << "][" << p
+              << "]) real parts disagree -- autocorrelation polarization "
+                 "matrix isn't Hermitian";
+          ASSERT_NEAR(v_pq.imag(), -v_qp.imag(), tolerance)
+              << "channel " << c << " receiver " << r << ": V[" << p << "][" << q
+              << "] and conj(V[" << q << "][" << p
+              << "]) imag parts disagree -- autocorrelation polarization "
+                 "matrix isn't Hermitian";
+        }
+      }
+    }
+  }
+}
+
+// Checks cuSOLVER's CUSOLVER_EIG_MODE_VECTOR contract for
+// cusolverDnXsyevBatched: eigenvalues come back in ascending order. They are
+// additionally non-negative for the same-polarization (p == q) blocks, since
+// those are genuine per-polarization receiver-covariance matrices and
+// therefore Hermitian positive-semi-definite; cross-polarization (p != q)
+// blocks aren't generally PSD so non-negativity isn't asserted there.
+template <typename Config>
+void assert_eigenvalues_ascending_nonnegative(
+    const typename Config::EigenvalueOutputType &eigenvalues,
+    float tolerance = 1e-4f) {
+  for (size_t c = 0; c < Config::NR_CHANNELS; ++c) {
+    for (size_t p = 0; p < Config::NR_POLARIZATIONS; ++p) {
+      for (size_t q = 0; q < Config::NR_POLARIZATIONS; ++q) {
+        float previous = -std::numeric_limits<float>::infinity();
+        for (size_t r = 0; r < Config::NR_RECEIVERS; ++r) {
+          const float value = eigenvalues[c][p][q][r];
+          ASSERT_GE(value, previous - tolerance)
+              << "channel " << c << " pol-pair (" << p << "," << q
+              << ") eigenvalue[" << r << "]=" << value
+              << " breaks ascending order (previous=" << previous << ")";
+          if (p == q) {
+            ASSERT_GE(value, -tolerance)
+                << "channel " << c << " polarization " << p << " eigenvalue["
+                << r << "]=" << value << " is negative";
+          }
+          previous = value;
+        }
+      }
+    }
+  }
+}
+
+// Finds the dominant frequency bin in `fft_output[channel][polarization][beam]`
+// and asserts it lands within `tolerance_bins` of `expected_bin`. Feeding a
+// known-frequency tone and checking where the energy lands is robust to
+// scaling/normalization-constant changes -- it validates "the FFT pipeline
+// does an FFT" without coupling to specific output magnitudes.
+template <typename Config>
+void assert_tone_detected(const typename Config::FFTOutputType &fft_output,
+                          size_t channel, size_t polarization, size_t beam,
+                          size_t expected_bin, size_t tolerance_bins = 1) {
+  constexpr size_t nr_bins = std::extent<typename Config::FFTOutputType, 3>::value;
+  static_assert(nr_bins > 0, "FFTOutputType must have a non-empty bin dimension");
+
+  size_t peak_bin = 0;
+  float peak_value = -std::numeric_limits<float>::infinity();
+  for (size_t bin = 0; bin < nr_bins; ++bin) {
+    const float value = fft_output[channel][polarization][beam][bin];
+    if (value > peak_value) {
+      peak_value = value;
+      peak_bin = bin;
+    }
+  }
+
+  const size_t distance =
+      peak_bin > expected_bin ? peak_bin - expected_bin : expected_bin - peak_bin;
+  ASSERT_LE(distance, tolerance_bins)
+      << "channel " << channel << " polarization " << polarization << " beam "
+      << beam << ": expected FFT peak within " << tolerance_bins
+      << " bin(s) of " << expected_bin << ", but the peak (value=" << peak_value
+      << ") is at bin " << peak_bin;
+}
+
+} // namespace test_support

--- a/tests/support/pipeline_harness.hpp
+++ b/tests/support/pipeline_harness.hpp
@@ -1,0 +1,168 @@
+#pragma once
+
+#include "spatial/output.hpp"
+#include "spatial/packet_formats.hpp"
+#include "spatial/pipeline.hpp"
+#include "spatial/pipeline_base.hpp"
+#include "spatial/spatial.hpp"
+#include "synthetic_packets.hpp"
+
+#include <array>
+#include <complex>
+#include <cuda_fp16.h>
+#include <memory>
+#include <unordered_map>
+#include <utility>
+
+// The shared pipeline-test driver: wires a real `ProcessorState` to a real
+// `GPUPipeline` via the production "synchronous pipeline" seam
+// (ProcessorState::handle_buffer_completion calls pipeline_->execute_pipeline
+// directly when synchronous_pipeline = true -- see spatial.hpp), feeds it
+// synthetic wire-format packets, and lets callers assert on whatever the
+// pipeline produced in a real `Output`.
+//
+// This intentionally drives the *real* ProcessorState ingestion path (not
+// DummyFinalPacketData's shortcut of poking LambdaConfig array layouts
+// directly) -- that's what "test at a high level" means here: the seam under
+// test is PacketInput -> ProcessorState -> Pipeline -> Output, the same one
+// production code uses end to end.
+namespace test_support {
+
+// Builds beam weights of unit magnitude / zero phase for every
+// channel/polarization/beam/receiver -- the "do nothing to the signal"
+// baseline used by test_pipeline.cu::Ex1 and friends.
+template <typename Config>
+BeamWeightsT<Config> make_unity_beam_weights() {
+  BeamWeightsT<Config> weights{};
+  const std::complex<__half> unity(__float2half(1.0f), __float2half(0.0f));
+  for (size_t c = 0; c < Config::NR_CHANNELS; ++c)
+    for (size_t p = 0; p < Config::NR_POLARIZATIONS; ++p)
+      for (size_t b = 0; b < Config::NR_BEAMS; ++b)
+        for (size_t r = 0; r < Config::NR_RECEIVERS; ++r)
+          weights.weights[c][p][b][r] = unity;
+  return weights;
+}
+
+// Builds antenna calibration gains of unit magnitude / zero phase -- the
+// "apply no calibration" baseline.
+template <typename Config>
+typename Config::AntennaGains make_unity_antenna_gains() {
+  typename Config::AntennaGains gains{};
+  for (size_t c = 0; c < Config::NR_CHANNELS; ++c)
+    for (size_t p = 0; p < Config::NR_POLARIZATIONS; ++p)
+      for (size_t r = 0; r < Config::NR_RECEIVERS; ++r)
+        gains[c][p][r] = std::complex<float>(1.0f, 0.0f);
+  return gains;
+}
+
+// Per-variant pipeline construction. The 7 `Lambda*Pipeline` classes take
+// genuinely different constructor arguments (e.g. LambdaGPUPipeline(int,
+// BeamWeightsT<T>*) vs LambdaAntennaSpectraPipeline(int) vs
+// LambdaProjectionPipeline<T, NR_EIG, NR_RUNS>(int)), so a single generic
+// factory isn't realistic -- these small per-variant helpers are it. Only the
+// one needed by this phase's self-test is implemented; the rest are added
+// incrementally as later phases need them.
+namespace pipeline_factories {
+
+template <typename Config>
+std::unique_ptr<LambdaGPUPipeline<Config>>
+make_gpu_pipeline(int num_buffers, BeamWeightsT<Config> *weights) {
+  return std::make_unique<LambdaGPUPipeline<Config>>(num_buffers, weights);
+}
+
+} // namespace pipeline_factories
+
+// Drives a complete synthetic correlation buffer through a real
+// ProcessorState -> GPUPipeline -> Output, synchronously.
+template <typename Config, size_t NR_BUFFERS = 3>
+class SyntheticPipelineRun {
+public:
+  explicit SyntheticPipelineRun(
+      GPUPipeline &pipeline, std::shared_ptr<Output> output,
+      std::array<int64_t, Config::NR_FPGA_SOURCES> fpga_delays = {},
+      std::unordered_map<uint32_t, int> fpga_id_map = {{0, 0}},
+      size_t min_freq_channel = 0)
+      : pipeline_(pipeline), output_(std::move(output)),
+        state_(Config::NR_PACKETS_FOR_CORRELATION,
+               Config::NR_TIME_STEPS_PER_PACKET, min_freq_channel, fpga_delays,
+               std::move(fpga_id_map)) {
+    pipeline_.set_state(&state_);
+    pipeline_.set_output(output_);
+    pipeline_.set_subpacket_delays(subpacket_delays_.data());
+
+    state_.set_pipeline(&pipeline_);
+    state_.synchronous_pipeline = true;
+  }
+
+  // Fills exactly one correlation buffer with synthetic packets -- mirroring
+  // ProcessorStateTest::FillOneBufferTest's proven fill order (packets
+  // 0..NR_PACKETS_FOR_CORRELATION for each channel/FPGA, followed by the "-1"
+  // initialization packet, since "sample num initialization is done off the
+  // first packet received") -- then drives the pipeline synchronously and
+  // waits for the GPU to finish.
+  //
+  //   sample_fn(channel, fpga, packet_index, time, receiver, polarization)
+  //       -> std::complex<int8_t>
+  //   scale_fn(channel, fpga, packet_index, receiver, polarization)
+  //       -> int16_t
+  //
+  // `packet_index` ranges over [-1, NR_PACKETS_FOR_CORRELATION].
+  template <typename SampleFn, typename ScaleFn>
+  void run(SampleFn &&sample_fn, ScaleFn &&scale_fn, uint64_t start_sample = 1000) {
+    const int nr_packets_for_correlation =
+        static_cast<int>(Config::NR_PACKETS_FOR_CORRELATION);
+
+    for (size_t channel = 0; channel < Config::NR_CHANNELS; ++channel) {
+      for (size_t fpga = 0; fpga < Config::NR_FPGA_SOURCES; ++fpga) {
+        for (int pkt = 0; pkt <= nr_packets_for_correlation; ++pkt) {
+          feed_packet(channel, fpga, pkt, start_sample, sample_fn, scale_fn);
+        }
+        feed_packet(channel, fpga, -1, start_sample, sample_fn, scale_fn);
+      }
+    }
+
+    state_.process_all_available_packets();
+    state_.handle_buffer_completion(true);
+    cudaDeviceSynchronize();
+  }
+
+  // Convenience overload for synthetic data that doesn't depend on
+  // channel/FPGA/packet index (the common case -- e.g. a constant value or a
+  // tone defined purely in terms of (time, receiver, polarization)).
+  template <typename SampleFn, typename ScaleFn>
+  void run_uniform(SampleFn &&sample_fn, ScaleFn &&scale_fn,
+                   uint64_t start_sample = 1000) {
+    run(
+        [&](size_t, size_t, int, int t, int r, int p) { return sample_fn(t, r, p); },
+        [&](size_t, size_t, int, int r, int p) { return scale_fn(r, p); },
+        start_sample);
+  }
+
+  ProcessorState<Config, NR_BUFFERS> &processor_state() { return state_; }
+
+private:
+  template <typename SampleFn, typename ScaleFn>
+  void feed_packet(size_t channel, size_t fpga, int pkt, uint64_t start_sample,
+                   SampleFn &sample_fn, ScaleFn &scale_fn) {
+    // Matches FillOneBufferTest's `start_sample + pkt *
+    // NR_TIME_STEPS_PER_PACKET` exactly, including its int/size_t/uint64_t mix
+    // -- for pkt == -1 this relies on unsigned wraparound to land on
+    // `start_sample - NR_TIME_STEPS_PER_PACKET`, which is the intended "one
+    // packet before the start" sample count.
+    const uint64_t sample_count =
+        start_sample + pkt * Config::NR_TIME_STEPS_PER_PACKET;
+
+    feed_lambda_packet<Config>(
+        state_, sample_count, static_cast<uint32_t>(fpga),
+        static_cast<uint16_t>(channel),
+        [&](int t, int r, int p) { return sample_fn(channel, fpga, pkt, t, r, p); },
+        [&](int r, int p) { return scale_fn(channel, fpga, pkt, r, p); });
+  }
+
+  GPUPipeline &pipeline_;
+  std::shared_ptr<Output> output_;
+  ProcessorState<Config, NR_BUFFERS> state_;
+  std::array<int, Config::NR_FPGA_SOURCES> subpacket_delays_{};
+};
+
+} // namespace test_support

--- a/tests/support/synthetic_packets.hpp
+++ b/tests/support/synthetic_packets.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+#include "spatial/packet_formats.hpp"
+#include "spatial/spatial.hpp"
+
+#include <complex>
+#include <cstdint>
+#include <cstring>
+#include <netinet/in.h>
+
+// Builders for synthetic on-the-wire LAMBDA packets (Ethernet + IP + UDP +
+// CustomHeader + payload), consolidating the near-duplicate byte-layout logic
+// that previously lived separately in tests/test_processor.cu
+// (`create_lambda_packet`) and tests/test_packet_formats.cpp
+// (`create_valid_test_packet`).
+namespace test_support {
+
+// Writes one wire-format packet for config `T` at `dest`, with sample/scale
+// values supplied by caller-provided generators:
+//   sample_fn(time_step, receiver, polarization) -> std::complex<int8_t>
+//   scale_fn(receiver, polarization)             -> int16_t
+//
+// `src_ip_octet3` is encoded into the source IP's third octet -- this is what
+// `LambdaConfig`'s `OVERWRITE_FPGA_ID_WITH_IP_THIRD_OCTET` parsing path reads
+// the FPGA id from (see TestIPThirdOctetFPGAIDParsing / LambdaPacketEntry).
+//
+// Returns the total packet length in bytes (Ethernet+IP+UDP+Custom+Payload),
+// i.e. how much of `dest` was written.
+template <typename T, typename SampleFn, typename ScaleFn>
+size_t build_lambda_wire_packet(uint8_t *dest, uint64_t sample_count,
+                                uint32_t fpga_id, uint16_t freq_channel,
+                                SampleFn &&sample_fn, ScaleFn &&scale_fn,
+                                uint8_t src_ip_octet3 = 0) {
+  uint8_t *data_ptr = dest;
+
+  EthernetHeader *eth = reinterpret_cast<EthernetHeader *>(data_ptr);
+  std::memset(eth, 0, sizeof(EthernetHeader));
+  eth->ethertype = htons(0x0800); // IPv4
+  data_ptr += sizeof(EthernetHeader);
+
+  IPHeader *ip = reinterpret_cast<IPHeader *>(data_ptr);
+  std::memset(ip, 0, sizeof(IPHeader));
+  ip->version_ihl = (4 << 4) | 5; // IPv4, IHL=5
+  ip->protocol = 17;              // UDP
+  // 10.0.<src_ip_octet3>.1, network byte order -- third octet carries the
+  // synthetic FPGA id when the config overwrites it from the IP address.
+  uint32_t host_ip = 0x0a000001;
+  host_ip = (host_ip & ~0x0000ff00U) |
+            (static_cast<uint32_t>(src_ip_octet3) << 8);
+  ip->src_ip = htonl(host_ip);
+  ip->dst_ip = htonl(0x0a000002);
+  data_ptr += sizeof(IPHeader);
+
+  UDPHeader *udp = reinterpret_cast<UDPHeader *>(data_ptr);
+  std::memset(udp, 0, sizeof(UDPHeader));
+  data_ptr += sizeof(UDPHeader);
+
+  CustomHeader *custom = reinterpret_cast<CustomHeader *>(data_ptr);
+  custom->sample_count = sample_count;
+  custom->fpga_id = fpga_id;
+  custom->freq_channel = freq_channel;
+  std::memset(custom->padding, 0, sizeof(custom->padding));
+  data_ptr += sizeof(CustomHeader);
+
+  auto *payload = reinterpret_cast<typename T::PacketPayloadType *>(data_ptr);
+  for (size_t r = 0; r < T::NR_RECEIVERS_PER_PACKET; ++r) {
+    for (size_t p = 0; p < T::NR_POLARIZATIONS; ++p) {
+      payload->scales[r][p] = scale_fn(static_cast<int>(r), static_cast<int>(p));
+    }
+  }
+  for (size_t t = 0; t < T::NR_TIME_STEPS_PER_PACKET; ++t) {
+    for (size_t r = 0; r < T::NR_RECEIVERS_PER_PACKET; ++r) {
+      for (size_t p = 0; p < T::NR_POLARIZATIONS; ++p) {
+        payload->data[t][r][p] = sample_fn(static_cast<int>(t), static_cast<int>(r),
+                                            static_cast<int>(p));
+      }
+    }
+  }
+
+  return sizeof(EthernetHeader) + sizeof(IPHeader) + sizeof(UDPHeader) +
+         sizeof(CustomHeader) + sizeof(typename T::PacketPayloadType);
+}
+
+// Convenience overload for the common case of a uniform sample value and a
+// uniform scale across the whole packet (mirrors create_lambda_packet's `int
+// val` shorthand).
+template <typename T>
+size_t build_constant_lambda_wire_packet(uint8_t *dest, uint64_t sample_count,
+                                         uint32_t fpga_id, uint16_t freq_channel,
+                                         std::complex<int8_t> sample_value,
+                                         int16_t scale_value,
+                                         uint8_t src_ip_octet3 = 0) {
+  return build_lambda_wire_packet<T>(
+      dest, sample_count, fpga_id, freq_channel,
+      [&](int, int, int) { return sample_value; },
+      [&](int, int) { return scale_value; }, src_ip_octet3);
+}
+
+// Builds one wire-format packet directly into a real ProcessorStateBase's
+// current write slot and pushes it through the same
+// get_current_write_pointer/add_received_packet_metadata/get_next_write_pointer
+// sequence that live packet capture uses (see ProcessorStateTest::add_packet
+// in test_processor.cu). This is the seam SyntheticPipelineRun drives.
+template <typename T, typename SampleFn, typename ScaleFn>
+void feed_lambda_packet(ProcessorStateBase &state, uint64_t sample_count,
+                        uint32_t fpga_id, uint16_t freq_channel,
+                        SampleFn &&sample_fn, ScaleFn &&scale_fn,
+                        uint8_t src_ip_octet3 = 0) {
+  uint8_t *data_ptr = reinterpret_cast<uint8_t *>(state.get_current_write_pointer());
+  size_t total_length = build_lambda_wire_packet<T>(
+      data_ptr, sample_count, fpga_id, freq_channel,
+      std::forward<SampleFn>(sample_fn), std::forward<ScaleFn>(scale_fn),
+      src_ip_octet3);
+
+  struct sockaddr_in addr {};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  state.add_received_packet_metadata(static_cast<int>(total_length), addr);
+  state.get_next_write_pointer();
+}
+
+} // namespace test_support

--- a/tests/support/test_configs.hpp
+++ b/tests/support/test_configs.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "spatial/packet_formats.hpp"
+
+// Canonical small `LambdaConfig` instantiations shared across pipeline tests.
+//
+// These intentionally mirror the smallest configs already proven to drive a
+// real GPU pipeline correctly end to end (test_pipeline.cu's
+// `Config`/`MultiFPGAConfig`), so that exact-value golden checks such as
+// test_pipeline.cu::Ex1's expected 8.0f/64.0f results keep working when ported
+// onto the shared harness in `pipeline_harness.hpp`.
+namespace test_support {
+
+// 1 channel, 1 FPGA source, 4 receivers -- the smallest layout that still
+// satisfies the Tensor Core Correlator's constraints (NR_RECEIVERS padded to a
+// multiple of 32, NR_POLARIZATIONS == 2; see CLAUDE.md "Domain gotchas").
+using SmallSingleFPGAConfig =
+    LambdaConfig<1,     // NR_CHANNELS
+                 1,     // NR_FPGA_SOURCES
+                 8,     // NR_TIME_STEPS_PER_PACKET
+                 4,     // NR_RECEIVERS
+                 2,     // NR_POLARIZATIONS
+                 4,     // NR_RECEIVERS_PER_PACKET
+                 1,     // NR_PACKETS_FOR_CORRELATION
+                 1,     // NR_BEAMS
+                 32,    // NR_PADDED_RECEIVERS
+                 32,    // NR_PADDED_RECEIVERS_PER_BLOCK
+                 10000  // NR_CORRELATED_BLOCKS_TO_ACCUMULATE
+                 >;
+
+// Same overall sizing, but the receivers are spread across 3 FPGA sources (2
+// receivers/packet each) -- exercises FPGA-to-FPGA delay alignment and
+// multi-source reassembly paths that SmallSingleFPGAConfig can't reach.
+using SmallMultiFPGAConfig =
+    LambdaConfig<1,     // NR_CHANNELS
+                 3,     // NR_FPGA_SOURCES
+                 8,     // NR_TIME_STEPS_PER_PACKET
+                 6,     // NR_RECEIVERS
+                 2,     // NR_POLARIZATIONS
+                 2,     // NR_RECEIVERS_PER_PACKET
+                 1,     // NR_PACKETS_FOR_CORRELATION
+                 1,     // NR_BEAMS
+                 32,    // NR_PADDED_RECEIVERS
+                 32,    // NR_PADDED_RECEIVERS_PER_BLOCK
+                 10000  // NR_CORRELATED_BLOCKS_TO_ACCUMULATE
+                 >;
+
+} // namespace test_support

--- a/tests/support/test_harness_selftest.cu
+++ b/tests/support/test_harness_selftest.cu
@@ -1,0 +1,125 @@
+// Self-test for the shared pipeline-test harness (SyntheticPipelineRun et al).
+//
+// It wires SyntheticPipelineRun<SmallSingleFPGAConfig> to a real
+// LambdaGPUPipeline and feeds it the exact same synthetic input
+// test_pipeline.cu::Ex1 hand-pokes into DummyFinalPacketData -- but through
+// the real ProcessorState ingestion seam instead. Reproducing Ex1's
+// hand-derived expected values (beam_data == (8, -8), visibilities == (64, 0))
+// end to end is the proof that the harness is wired correctly; it also
+// demonstrates both testing styles the harness is meant to support: exact-value
+// goldens (where the math is simple enough to hand-derive) and property-based
+// invariant checks (the "high level, not implementation-coupled" style for
+// everything else).
+#include "spatial/output.hpp"
+#include "spatial/packet_formats.hpp"
+#include "spatial/pipeline.hpp"
+#include "spatial/pipeline_base.hpp"
+#include "spatial/spatial.hpp"
+
+#include "support/assertions.hpp"
+#include "support/pipeline_harness.hpp"
+#include "support/synthetic_packets.hpp"
+#include "support/test_configs.hpp"
+
+#include <complex>
+#include <cstdint>
+#include <cuda_fp16.h>
+#include <gtest/gtest.h>
+#include <memory>
+
+namespace {
+
+using Config = test_support::SmallSingleFPGAConfig;
+
+class PipelineHarnessSelfTest : public ::testing::Test {
+protected:
+  void TearDown() override {
+    cudaDeviceSynchronize();
+    cudaDeviceReset();
+  }
+};
+
+// Constant (2, -2) sample / scale-1 input across every channel, FPGA, packet
+// slot, time step, receiver and polarization -- the exact values Ex1 fills
+// DummyFinalPacketData with by hand. With unity beam weights and
+// NR_RECEIVERS == 4, Ex1 hand-derived beam_data == (8, -8) and visibilities ==
+// (64, 0) for every index from these inputs.
+std::complex<int8_t> constant_sample(size_t /*channel*/, size_t /*fpga*/,
+                                     int /*packet*/, int /*time*/,
+                                     int /*receiver*/, int /*polarization*/) {
+  return std::complex<int8_t>(2, -2);
+}
+
+int16_t constant_scale(size_t /*channel*/, size_t /*fpga*/, int /*packet*/,
+                       int /*receiver*/, int /*polarization*/) {
+  return 1;
+}
+
+struct HarnessRun {
+  std::shared_ptr<SingleHostMemoryOutput<Config>> output;
+  BeamWeightsT<Config> weights;
+  std::unique_ptr<LambdaGPUPipeline<Config>> pipeline;
+  std::unique_ptr<test_support::SyntheticPipelineRun<Config>> driver;
+};
+
+HarnessRun run_ex1_equivalent() {
+  HarnessRun run;
+  run.output = std::make_shared<SingleHostMemoryOutput<Config>>();
+  run.weights = test_support::make_unity_beam_weights<Config>();
+  run.pipeline = test_support::pipeline_factories::make_gpu_pipeline<Config>(
+      Config::NR_PACKETS_FOR_CORRELATION, &run.weights);
+  run.driver = std::make_unique<test_support::SyntheticPipelineRun<Config>>(
+      *run.pipeline, run.output);
+
+  run.driver->run(constant_sample, constant_scale);
+  run.pipeline->dump_visibilities();
+  cudaDeviceSynchronize();
+  return run;
+}
+
+} // namespace
+
+TEST_F(PipelineHarnessSelfTest, ReproducesEx1ExactValues) {
+  HarnessRun run = run_ex1_equivalent();
+  const auto &beam_data = *run.output->beam_data;
+  const auto &visibilities = *run.output->visibilities;
+
+  constexpr size_t nr_samples =
+      Config::NR_PACKETS_FOR_CORRELATION * Config::NR_TIME_STEPS_PER_PACKET;
+
+  for (size_t c = 0; c < Config::NR_CHANNELS; ++c) {
+    for (size_t pol_a = 0; pol_a < Config::NR_POLARIZATIONS; ++pol_a) {
+      for (size_t beam = 0; beam < Config::NR_BEAMS; ++beam) {
+        for (size_t t = 0; t < nr_samples; ++t) {
+          EXPECT_EQ(__half2float(beam_data[c][pol_a][beam][t][0]), 8.0f)
+              << "beam_data real mismatch at channel=" << c << " pol=" << pol_a
+              << " beam=" << beam << " sample=" << t;
+          EXPECT_EQ(__half2float(beam_data[c][pol_a][beam][t][1]), -8.0f)
+              << "beam_data imag mismatch at channel=" << c << " pol=" << pol_a
+              << " beam=" << beam << " sample=" << t;
+        }
+      }
+
+      for (size_t pol_b = 0; pol_b < Config::NR_POLARIZATIONS; ++pol_b) {
+        for (size_t baseline = 0; baseline < Config::NR_BASELINES_UNPADDED; ++baseline) {
+          EXPECT_EQ(visibilities[c][baseline][pol_a][pol_b][0], 64.0f)
+              << "visibilities real mismatch at channel=" << c
+              << " baseline=" << baseline << " pol_a=" << pol_a
+              << " pol_b=" << pol_b;
+          EXPECT_EQ(visibilities[c][baseline][pol_a][pol_b][1], 0.0f)
+              << "visibilities imag mismatch at channel=" << c
+              << " baseline=" << baseline << " pol_a=" << pol_a
+              << " pol_b=" << pol_b;
+        }
+      }
+    }
+  }
+}
+
+TEST_F(PipelineHarnessSelfTest, SatisfiesPhysicalInvariants) {
+  HarnessRun run = run_ex1_equivalent();
+
+  test_support::assert_all_finite(*run.output->beam_data, "beam_data");
+  test_support::assert_all_finite(*run.output->visibilities, "visibilities");
+  test_support::assert_autocorrelation_invariants<Config>(*run.output->visibilities);
+}


### PR DESCRIPTION
Of the 7 Lambda*Pipeline GPU pipeline variants, only LambdaGPUPipeline had test coverage, via test_pipeline.cu's ~1,300-line Ex1 and friends -- mostly copy-pasteable setup boilerplate (synthetic packets, pipeline construction, output wiring, buffer-fill/flush, GPU sync). tests/support/ extracts that 80% into a reusable harness so testing a new variant becomes "construct it, call .run(...), assert invariants on the Output":

- test_configs.hpp: canonical small LambdaConfig instantiations (SmallSingleFPGAConfig, SmallMultiFPGAConfig)
- synthetic_packets.hpp: build_lambda_wire_packet/feed_lambda_packet -- builds correctly-laid-out wire packets parameterized by sample/scale generator callbacks, consolidating near-duplicate builders from test_processor.cu and test_packet_formats.cpp
- pipeline_harness.hpp: SyntheticPipelineRun<Config>, which drives the real production seam end to end (PacketInput -> ProcessorState -> GPUPipeline -> Output, via the synchronous_pipeline path), plus per-variant pipeline factories and unity weight/gain helpers
- assertions.hpp: property/invariant checks (finiteness, autocorrelation Hermitian-PSD structure, eigenvalue ordering, FFT tone detection) that encode physical/mathematical truths rather than implementation details, so they survive the planned pipeline.hpp refactor instead of breaking with it
- test_harness_selftest.cu: PipelineHarnessSelfTest, proving the harness reproduces test_pipeline.cu::Ex1's hand-derived golden values (beam_data == (8,-8), visibilities == (64,0)) end to end

Also adds tests/TESTING.md documenting the harness strategy and two non-obvious findings it surfaced (the correlator's packed-triangular baseline storage limits what Hermitian-symmetry checks are possible, and a likely latent race between cudaLaunchHostFunc-queued buffer release and the arrivals-array memcpy in LambdaPipelineIngest::ingest_and_scale), and updates CLAUDE.md with the build/test recipe for this docker-container environment plus the two gotchas that block it otherwise (GLIBC linker symbol-versioning mismatch between conda's bundled sysroot and the system glibc, and CUDA_HOME needed for NVRTC's cooperative_groups header lookup).

Verified with the full suite: 29/29 tests pass (27 existing + 2 new), zero regressions.