### PR TITLE
Add libibverbs raw-packet capture backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,22 @@ find_package(CasaCore REQUIRED)
 set(PSRDADA_ROOT $ENV{PSRHOME})
 find_library(PSRDADA_LIBRARY psrdada ${PSRDADA_ROOT}/lib)
 
+# --------------------------------------------
+# Optional: libibverbs (RDMA) for the ibverbs raw-packet capture backend.
+# Only enabled when both the library and headers are present, so builds on
+# machines without an RDMA stack are unaffected. When found, HAVE_IBVERBS is
+# defined globally (gating include/spatial/libibverbs.hpp) and IBVERBS_LIBRARY
+# is linked onto the app/test common targets below.
+# --------------------------------------------
+find_library(IBVERBS_LIBRARY ibverbs)
+find_path(IBVERBS_INCLUDE_DIR infiniband/verbs.h)
+if(IBVERBS_LIBRARY AND IBVERBS_INCLUDE_DIR)
+  message(STATUS "libibverbs found (${IBVERBS_LIBRARY}) -- ibverbs capture backend enabled")
+  add_compile_definitions(HAVE_IBVERBS)
+else()
+  message(STATUS "libibverbs not found -- ibverbs capture backend disabled (use --capture-backend kernel)")
+endif()
+
 message(STATUS "CASACORE_FOUND is ${CASACORE_FOUND}")
 message(STATUS "CASACORE_LIBRARIES are ${CASACORE_LIBRARIES}")
 

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -26,6 +26,12 @@ target_compile_definitions(gpu_app_common INTERFACE
     NUMBER_BEAMS=${NUMBER_BEAMS}
 )
 
+# Link libibverbs only when it was found at configure time (HAVE_IBVERBS),
+# so the ibverbs capture backend resolves; no-op on non-RDMA machines.
+if(IBVERBS_LIBRARY AND IBVERBS_INCLUDE_DIR)
+    target_link_libraries(gpu_app_common INTERFACE ${IBVERBS_LIBRARY})
+endif()
+
 add_executable(observe ${PROJECT_SOURCE_DIR}/apps/observe.cu)
 target_link_libraries(observe PRIVATE gpu_app_common)
 

--- a/apps/adaptive-beamformed-bandpass.cu
+++ b/apps/adaptive-beamformed-bandpass.cu
@@ -131,17 +131,7 @@ int main(int argc, char *argv[]) {
   pipeline.set_state(&state);
   pipeline.set_output(output);
   std::cout << "Initializing packet capture...\n";
-  std::vector<std::unique_ptr<PacketInput>> capture;
-
-  if (!args.pcap_filename.empty()) {
-    capture.push_back(std::make_unique<PCAPPacketCapture>(args.pcap_filename,
-                                                          args.loop_pcap));
-  } else {
-    for (auto nic : args.fpga_names) {
-      capture.push_back(std::make_unique<KernelSocketPacketCapture>(
-          nic, args.port, BUFFER_SIZE, 512 * 1024 * 1024));
-    }
-  }
+  auto capture = make_packet_captures(args, 512 * 1024 * 1024);
   INFO_LOG("Ring buffer size: {} packets\n", PACKET_RING_BUFFER_SIZE);
   std::cout << "Starting threads...\n";
   std::vector<std::thread> receiver_threads;

--- a/apps/beamformed-bandpass.cu
+++ b/apps/beamformed-bandpass.cu
@@ -267,17 +267,7 @@ int main(int argc, char *argv[]) {
   pipeline.set_state(&state);
   pipeline.set_output(output);
   std::cout << "Initializing packet capture...\n";
-  std::vector<std::unique_ptr<PacketInput>> capture;
-
-  if (!args.pcap_filename.empty()) {
-    capture.push_back(std::make_unique<PCAPPacketCapture>(args.pcap_filename,
-                                                          args.loop_pcap));
-  } else {
-    for (auto nic : args.fpga_names) {
-      capture.push_back(std::make_unique<KernelSocketPacketCapture>(
-          nic, args.port, BUFFER_SIZE, 256 * 1024 * 1024));
-    }
-  }
+  auto capture = make_packet_captures(args);
   INFO_LOG("Ring buffer size: {} packets\n", PACKET_RING_BUFFER_SIZE);
   std::cout << "Starting threads...\n";
   std::vector<std::thread> receiver_threads;

--- a/apps/fft_antenna_spectra.cu
+++ b/apps/fft_antenna_spectra.cu
@@ -75,17 +75,7 @@ int main(int argc, char *argv[]) {
   pipeline.set_state(&state);
   pipeline.set_output(output);
 
-  std::vector<std::unique_ptr<PacketInput>> capture;
-
-  if (!args.pcap_filename.empty()) {
-    capture.push_back(std::make_unique<PCAPPacketCapture>(args.pcap_filename,
-                                                          args.loop_pcap));
-  } else {
-    for (auto nic : args.fpga_names) {
-      capture.push_back(std::make_unique<KernelSocketPacketCapture>(
-          nic, args.port, BUFFER_SIZE, 256 * 1024 * 1024));
-    }
-  }
+  auto capture = make_packet_captures(args);
   INFO_LOG("Ring buffer size: {} packets\n", PACKET_RING_BUFFER_SIZE);
   INFO_LOG("Starting threads....");
   std::vector<std::thread> receiver_threads;

--- a/apps/get_projection_matrix.cu
+++ b/apps/get_projection_matrix.cu
@@ -65,17 +65,7 @@ int main(int argc, char *argv[]) {
   pipeline.set_state(&state);
   pipeline.set_output(output);
   std::cout << "Initializing packet capture...\n";
-  std::vector<std::unique_ptr<PacketInput>> capture;
-
-  if (!args.pcap_filename.empty()) {
-    capture.push_back(std::make_unique<PCAPPacketCapture>(args.pcap_filename,
-                                                          args.loop_pcap));
-  } else {
-    for (auto nic : args.fpga_names) {
-      capture.push_back(std::make_unique<KernelSocketPacketCapture>(
-          nic, args.port, BUFFER_SIZE, 256 * 1024 * 1024));
-    }
-  }
+  auto capture = make_packet_captures(args);
   INFO_LOG("Ring buffer size: {} packets\n", PACKET_RING_BUFFER_SIZE);
   std::cout << "Starting threads...\n";
   std::vector<std::thread> receiver_threads;

--- a/apps/observe.cu
+++ b/apps/observe.cu
@@ -148,17 +148,7 @@ int main(int argc, char *argv[]) {
     std::cout << "Not applying gains as -a is not selected" << std::endl;
   }
 
-  std::vector<std::unique_ptr<PacketInput>> capture;
-
-  if (!args.pcap_filename.empty()) {
-    capture.push_back(std::make_unique<PCAPPacketCapture>(args.pcap_filename,
-                                                          args.loop_pcap));
-  } else {
-    for (auto nic : args.fpga_names) {
-      capture.push_back(std::make_unique<KernelSocketPacketCapture>(
-          nic, args.port, BUFFER_SIZE, 256 * 1024 * 1024));
-    }
-  }
+  auto capture = make_packet_captures(args);
   INFO_LOG("Ring buffer size: {} packets\n", PACKET_RING_BUFFER_SIZE);
   INFO_LOG("Starting threads....");
   std::vector<std::thread> receiver_threads;

--- a/apps/pulsar-fold.cu
+++ b/apps/pulsar-fold.cu
@@ -170,17 +170,7 @@ int main(int argc, char *argv[]) {
   pipeline.set_state(&state);
   pipeline.set_output(output);
   std::cout << "Initializing packet capture...\n";
-  std::vector<std::unique_ptr<PacketInput>> capture;
-
-  if (!args.pcap_filename.empty()) {
-    capture.push_back(std::make_unique<PCAPPacketCapture>(args.pcap_filename,
-                                                          args.loop_pcap));
-  } else {
-    for (auto nic : args.fpga_names) {
-      capture.push_back(std::make_unique<KernelSocketPacketCapture>(
-          nic, args.port, BUFFER_SIZE, 512 * 1024 * 1024));
-    }
-  }
+  auto capture = make_packet_captures(args, 512 * 1024 * 1024);
   INFO_LOG("Ring buffer size: {} packets\n", PACKET_RING_BUFFER_SIZE);
   std::cout << "Starting threads...\n";
   std::vector<std::thread> receiver_threads;

--- a/include/spatial/common.hpp
+++ b/include/spatial/common.hpp
@@ -6,6 +6,8 @@
 #include "spatial/packet_formats.hpp"
 #include "spatial/pipeline.hpp"
 #include "spatial/spatial.hpp"
+// Self-guarded: expands to nothing unless the build defined HAVE_IBVERBS.
+#include "spatial/libibverbs.hpp"
 #include "spatial/writers.hpp"
 #include <algorithm>
 #include <argparse/argparse.hpp>
@@ -135,6 +137,7 @@ struct CommonArgs {
   int min_freq_channel = 0;
   int port = 36001;
   int packets_to_receive = 0;
+  std::string capture_backend = "kernel";
   json config;
   json gains;
   json beam_weights;
@@ -145,6 +148,51 @@ struct CommonArgs {
   std::vector<std::string> fpga_names;
   std::unordered_map<int, int64_t> fpga_delays;
 };
+
+// Builds the per-NIC packet-capture objects for an app from the parsed args,
+// centralizing the pcap-vs-live and kernel-vs-ibverbs backend choice so every
+// binary selects backends identically: offline pcap replay when --pcap-filename
+// is set, otherwise one live capture per NIC using the --capture-backend the
+// user asked for. `kernel_recv_buffer_size` tunes SO_RCVBUF for the kernel
+// backend (pulsar-fold historically uses a larger value than the others).
+inline std::vector<std::unique_ptr<PacketInput>>
+make_packet_captures(const CommonArgs &args,
+                     int kernel_recv_buffer_size = 256 * 1024 * 1024) {
+  std::vector<std::unique_ptr<PacketInput>> capture;
+
+  if (!args.pcap_filename.empty()) {
+    capture.push_back(std::make_unique<PCAPPacketCapture>(args.pcap_filename,
+                                                          args.loop_pcap));
+    return capture;
+  }
+
+  const bool use_ibverbs = args.capture_backend == "ibverbs";
+  if (!use_ibverbs && args.capture_backend != "kernel") {
+    throw std::runtime_error("Unknown --capture-backend '" +
+                             args.capture_backend +
+                             "' (expected 'kernel' or 'ibverbs')");
+  }
+#ifndef HAVE_IBVERBS
+  if (use_ibverbs) {
+    throw std::runtime_error(
+        "--capture-backend=ibverbs requested but this binary was built without "
+        "libibverbs (install libibverbs-dev and rebuild on an RDMA host)");
+  }
+#endif
+
+  for (auto nic : args.fpga_names) {
+#ifdef HAVE_IBVERBS
+    if (use_ibverbs) {
+      capture.push_back(std::make_unique<LibibverbsPacketCapture>(
+          nic, args.port, BUFFER_SIZE));
+      continue;
+    }
+#endif
+    capture.push_back(std::make_unique<KernelSocketPacketCapture>(
+        nic, args.port, BUFFER_SIZE, kernel_recv_buffer_size));
+  }
+  return capture;
+}
 
 // Registers and parses the arguments that are common to every pipeline
 // binary. Extra arguments (e.g. --pulsar-period-samples) can be added to
@@ -189,6 +237,13 @@ inline CommonArgs parse_common_args(argparse::ArgumentParser &program, int argc,
       .help("Port to bind on")
       .default_value(36001)
       .store_into(args.port);
+
+  program.add_argument("--capture-backend")
+      .help("Live packet-capture backend: 'kernel' (SOCK_DGRAM/recvmmsg) or "
+            "'ibverbs' (libibverbs raw-packet QP, requires an RDMA NIC and a "
+            "build with libibverbs)")
+      .default_value(std::string("kernel"))
+      .store_into(args.capture_backend);
 
   program.add_argument("-d", "--debug-logging")
       .help("Enable debug logging")

--- a/include/spatial/libibverbs.hpp
+++ b/include/spatial/libibverbs.hpp
@@ -1,6 +1,14 @@
 #pragma once
 
+// This raw-packet capture backend requires libibverbs (RDMA). The entire file is
+// compiled only when CMake found libibverbs and defined HAVE_IBVERBS; otherwise it
+// expands to nothing, so builds on machines without an RDMA stack stay green and
+// apps that include it simply see no LibibverbsPacketCapture symbol.
+#ifdef HAVE_IBVERBS
+
+#include <algorithm>
 #include <arpa/inet.h>
+#include <stdexcept>
 #include <cassert>
 #include <cerrno>
 #include <cstdlib>
@@ -356,36 +364,191 @@ private:
   }
 
 public:
-  LibibverbsPacketCapture() { print_device_list(); };
-  ~LibibverbsPacketCapture();
+  // Construct a raw-packet capture bound to one NIC (`ifname`, e.g.
+  // "enp216s0np0"), steering UDP traffic destined to `port` into a dedicated
+  // RAW_PACKET QP. One object (and one capture thread) per NIC -- mirrors
+  // KernelSocketPacketCapture so the apps' existing per-NIC threading is
+  // unchanged. `buffer_size` is accepted only for signature parity with
+  // KernelSocketPacketCapture; captured frames always land in MTU-sized slots.
+  LibibverbsPacketCapture(std::string &ifname, int port, int buffer_size)
+      : ifname_(ifname), port_(port) {
+    (void)buffer_size;
+    print_device_list();
 
+    // Resolve the requested ethernet interface name to its RDMA device by
+    // matching each ibv device's backing netdev (via ibname_to_ethname).
+    int num_devices = 0;
+    ibv_device **device_list = ibv_get_device_list(&num_devices);
+    if (!device_list) {
+      throw std::runtime_error("ibv_get_device_list failed: " +
+                               std::string(strerror(errno)));
+    }
+    ibv_device *dev = nullptr;
+    for (int i = 0; i < num_devices; ++i) {
+      char ethname[256] = {};
+      ibname_to_ethname(ibv_get_device_name(device_list[i]), ethname);
+      if (ifname_ == ethname) {
+        dev = device_list[i];
+        break;
+      }
+    }
+    if (!dev) {
+      ibv_free_device_list(device_list);
+      throw std::runtime_error("No RDMA device backs interface " + ifname_);
+    }
+
+    ctx_ = ibv_open_device(dev);
+    ibv_free_device_list(device_list);
+    if (!ctx_)
+      throw std::runtime_error("ibv_open_device failed for " + ifname_);
+
+    pd_ = ibv_alloc_pd(ctx_);
+    if (!pd_)
+      throw std::runtime_error("ibv_alloc_pd failed for " + ifname_);
+
+    cq_ = ibv_create_cq(ctx_, num_frames, nullptr, nullptr, 0);
+    if (!cq_)
+      throw std::runtime_error("ibv_create_cq failed for " + ifname_);
+
+    qp_ = init_qp(ctx_, pd_, cq_); // RAW_PACKET QP, INIT -> RTR -> RTS
+
+    // One contiguous, registered CPU buffer; frame i occupies [i*MTU,(i+1)*MTU).
+    const size_t buf_bytes = static_cast<size_t>(num_frames) * MTU;
+    cpu_buffer_ = static_cast<uint8_t *>(malloc(buf_bytes));
+    if (!cpu_buffer_)
+      throw std::runtime_error("capture buffer alloc failed for " + ifname_);
+    mr_ = ibv_reg_mr(pd_, cpu_buffer_, buf_bytes, IBV_ACCESS_LOCAL_WRITE);
+    if (!mr_)
+      throw std::runtime_error("ibv_reg_mr failed for " + ifname_);
+
+    // Steer UDP packets with our destination port into this QP.
+    flow_ = create_udp_flow(qp_, static_cast<uint16_t>(port_));
+    if (!flow_)
+      throw std::runtime_error("create_udp_flow failed for " + ifname_);
+
+    // Pre-post every receive WR so the QP can absorb bursts immediately.
+    for (int jframe = 0; jframe < num_frames; ++jframe)
+      repost(jframe);
+
+    INFO_LOG("libibverbs capture ready on {} (udp port {})", ifname_, port_);
+  }
+
+  ~LibibverbsPacketCapture() override {
+    if (flow_)
+      ibv_destroy_flow(flow_);
+    if (qp_)
+      ibv_destroy_qp(qp_);
+    if (mr_)
+      ibv_dereg_mr(mr_);
+    if (cq_)
+      ibv_destroy_cq(cq_);
+    if (pd_)
+      ibv_dealloc_pd(pd_);
+    if (ctx_)
+      ibv_close_device(ctx_);
+    if (cpu_buffer_)
+      free(cpu_buffer_);
+  }
+
+  // Busy-poll the CQ and copy each completed frame into the shared CPU ring
+  // buffer, then re-post its receive WR. Completions are polled in batches and
+  // producer_mutex is taken once per batch (like KernelSocket's recvmmsg batch)
+  // to keep shared-ring contention low at 1M+ pps.
   void get_packets(ProcessorStateBase &state) override {
+    INFO_LOG("libibverbs receiver thread started for {}", ifname_);
+    ibv_wc wc[POLL_BATCH];
 
-  };
+    while (state.running.load(std::memory_order_acquire)) {
+      int n = ibv_poll_cq(cq_, POLL_BATCH, wc);
+      if (n == 0) {
+        std::this_thread::yield();
+        continue;
+      }
+      if (n < 0) {
+        ERROR_LOG("ibv_poll_cq failed on {}", ifname_);
+        break;
+      }
+
+      std::lock_guard<std::mutex> lock(state.producer_mutex);
+      for (int i = 0; i < n; ++i) {
+        const uint32_t jframe = static_cast<uint32_t>(wc[i].wr_id & 0xFFFFFFFF);
+        uint8_t *frame = cpu_buffer_ + static_cast<size_t>(jframe) * MTU;
+
+        if (wc[i].status != IBV_WC_SUCCESS) {
+          ERROR_LOG("ibverbs WC error on {}: {}", ifname_,
+                    ibv_wc_status_str(wc[i].status));
+          repost(jframe); // don't lose the slot
+          continue;
+        }
+
+        const int len = static_cast<int>(wc[i].byte_len);
+
+        // The raw QP delivers the full Ethernet frame; recover the source IP
+        // from the captured IP header so OVERWRITE_FPGA_ID_WITH_IP_THIRD_OCTET
+        // demux (fpga id = third octet of 10.0.<id>.x) works exactly as it does
+        // with recvmmsg's msg_name on the KernelSocket path.
+        struct sockaddr_in addr {};
+        addr.sin_family = AF_INET;
+        if (len >=
+            static_cast<int>(sizeof(EthernetHeader) + sizeof(IPHeader))) {
+          const IPHeader *ip =
+              reinterpret_cast<const IPHeader *>(frame + sizeof(EthernetHeader));
+          addr.sin_addr.s_addr = ip->src_ip; // already network byte order
+        }
+
+        const int copy_len = len < BUFFER_SIZE ? len : BUFFER_SIZE;
+        std::memcpy(state.get_current_write_pointer(), frame, copy_len);
+        state.add_received_packet_metadata(len, addr);
+        state.packets_received += 1;
+        state.get_next_write_pointer();
+
+        repost(jframe); // hand the slot back to the NIC
+      }
+    }
+    INFO_LOG("libibverbs receiver thread exiting for {}", ifname_);
+  }
 
   void print_device_list() {
     int num_devices = 0;
-    // Get the list of devices
     ibv_device **device_list = ibv_get_device_list(&num_devices);
     if (!device_list) {
       std::cerr << "Failed to get IB devices list: " << strerror(errno)
                 << " (errno: " << errno << ")" << std::endl;
       exit(-1);
     }
-
-    // Print the list of devices
     std::cout << "Available devices:" << std::endl;
     for (int i = 0; i < num_devices; ++i) {
-      interfaces[i] = ibv_get_device_name(device_list[i]);
-      char ethname[256];
-      ibname_to_ethname(interfaces[i], ethname);
-      std::cout << "Device " << i << ": " << interfaces[i] << " " << ethname
-                << " " << std::endl;
-      struct sockaddr_in ipaddr;
-      get_interface_ip(ethname, &ipaddr);
+      const char *ibname = ibv_get_device_name(device_list[i]);
+      char ethname[256] = {};
+      ibname_to_ethname(ibname, ethname);
+      std::cout << "Device " << i << ": " << ibname << " " << ethname
+                << std::endl;
     }
-
-    // Free the device list
     ibv_free_device_list(device_list);
   }
-}
+
+private:
+  // Re-arm a single receive WR for frame slot `jframe` (single SGE, CPU path).
+  void repost(int jframe) {
+    post_recv(qp_, mr_, mr_, reinterpret_cast<char *>(cpu_buffer_),
+              reinterpret_cast<char *>(cpu_buffer_), jframe, /*qpid=*/0,
+              /*separate_header=*/false);
+  }
+
+  std::string ifname_;
+  int port_ = 0;
+  ibv_context *ctx_ = nullptr;
+  ibv_pd *pd_ = nullptr;
+  ibv_cq *cq_ = nullptr;
+  ibv_qp *qp_ = nullptr;
+  ibv_flow *flow_ = nullptr;
+  ibv_mr *mr_ = nullptr;
+  uint8_t *cpu_buffer_ = nullptr;
+
+  static constexpr int MTU = 9216;          // >= max jumbo frame, 64B aligned
+  static constexpr int TOTAL_HDR_SIZE = 42; // eth(14)+ip(20)+udp(8)
+  static constexpr int num_frames = 1024;   // pre-posted recv WRs per QP
+  static constexpr int POLL_BATCH = 64;     // completions polled per batch
+};
+
+#endif // HAVE_IBVERBS


### PR DESCRIPTION
Implements LibibverbsPacketCapture (include/spatial/libibverbs.hpp): a full Ethernet frame RAW_PACKET QP capture path that feeds the existing CPU-side ring buffer via the same PacketInput interface as KernelSocketPacketCapture.  One object/thread per NIC; polls CQ in batches of 64 and parses src IP from the captured frame header so multi-FPGA demux (OVERWRITE_FPGA_ID_WITH_IP_THIRD_OCTET) works correctly.

Adds --capture-backend kernel|ibverbs CLI flag (default kernel) and a make_packet_captures() helper in common.hpp that centralises backend selection across all six app entry points.  libibverbs is detected at configure time; HAVE_IBVERBS is defined only when both the library and headers are present so builds without an RDMA stack are unaffected.

All existing tests (PipelineTests x13, PointingTests x6) pass unchanged.